### PR TITLE
Added support for QuickConnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * This is a small framework to consume **Synology DSM's Web API**
 * Supports **HTTP** and **HTTPS**
 * Supports OTP code for login
+* Supports [QuickConnect](https://kb.synology.com/en-uk/DSM/help/DSM/AdminCenter/connection_quickconnect?version=7)
 * SSL certificate validation can be disabled (only for SynoClient, does not affect the AppDomain)
 
 ## NuGet packages
@@ -64,7 +65,7 @@ This example shows how to configure the connection and login with username and p
 var audioStation = new AudioStationClient();
 
 // Create the SynoClient which communicates with the server, this can be re-used across all Station Clients.
-var client = new SynoClient(new Uri("https://MySynolgyNAS:5001/"), audioStation);
+var client = await SynoClient.Create(SynoConnectionDetails.ForUri("https://MySynolgyNAS:5001/"), audioStation);
 
 // Login
 await client.LoginAsync("username", "password");
@@ -98,8 +99,15 @@ If you make a request anyway after login to fetch your data, this is the recomme
 You can pass your OTP code for login 
 
 ```csharp
-var client = new SynoClient(new Uri("https://MySynolgyNAS:5001/"), audioStation);
+var client = await SynoClient.Create(SynoConnectionDetails.ForUri("https://MySynolgyNAS:5001/"), audioStation);
 await client.LoginAsync("username", "password", "123456");
+```
+
+### Connect using QuickConnect id
+You can use a QuickConnect id to resolve the actual host
+
+```csharp
+var client = await SynoClient.Create(SynoConnectionDetails.ForQuickConnectId("MyQuickConnectId"), audioStation);
 ```
 
 ## How to begin development?

--- a/SynologyDotNet.Core/Helpers/HttpClientHelper.cs
+++ b/SynologyDotNet.Core/Helpers/HttpClientHelper.cs
@@ -86,6 +86,7 @@ namespace SynologyDotNet.Core.Helpers
 
             // Set User agent
             client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; EN; rv:11.0) like Gecko");
+            client.DefaultRequestHeaders.TryAddWithoutValidation("Accept-Charset", "ISO-8859-1"); //Todo: Is this really necessary?
             return client;
         }
     }

--- a/SynologyDotNet.Core/Helpers/QuickConnectUriResolver.cs
+++ b/SynologyDotNet.Core/Helpers/QuickConnectUriResolver.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SynologyDotNet.Core.Helpers
+{
+    /// <summary>
+    /// Helps to resolve the URI to access a Synology using its quick connect id
+    /// </summary>
+    public static class QuickConnectUriResolver
+    {
+        /// <summary>
+        /// Resolved the server for the given quick connect id by requesting connection details at quickconnect.to
+        /// </summary>
+        public static async Task<Uri> Resolve(string quickConnectId)
+        {
+            var client = new HttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://global.quickconnect.to/Serv.php");
+            var content = new StringContent($@"[
+    {{
+        ""version"": 1,
+        ""command"": ""request_tunnel"",
+        ""stop_when_error"": false,
+        ""stop_when_success"": true,
+        ""id"": ""dsm_portal_https"",
+        ""serverID"": ""{quickConnectId}"",
+        ""is_gofile"": false
+    }}
+]", null, "application/x-www-form-urlencoded");
+            request.Content = content;
+            var response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var data = JsonConvert.DeserializeObject(responseContent) as JArray;
+            var relayRegion = data.First.SelectToken("env.relay_region").Value<string>();
+            var controlHost = data.First.SelectToken("env.control_host").Value<string>();
+            var strippedControlHost = controlHost.Substring(controlHost.IndexOf(".", StringComparison.Ordinal) + 1);
+
+            return new Uri($"https://{quickConnectId}.{relayRegion}.{strippedControlHost}/");
+        }
+    }
+}

--- a/SynologyDotNet.Core/SynoClient.cs
+++ b/SynologyDotNet.Core/SynoClient.cs
@@ -295,11 +295,6 @@ namespace SynologyDotNet
             {
                 if (loginResult.Success && response.Headers.TryGetValues("Set-Cookie", out var cookies))
                 {
-                    if (response.RequestMessage.Headers.TryGetValues("Cookie", out var requestCookies))
-                    {
-                        cookies = cookies.Concat(requestCookies);
-                    }
-
                     var result = new SynoSession()
                     {
                         Name = session,
@@ -543,11 +538,6 @@ namespace SynologyDotNet
         public async Task<T> QueryObjectAsync<T>(RequestBuilder req, CancellationToken cancellationToken)
         {
             var response = await _httpClient.SendAsync(await req.ToPostRequestAsync(), cancellationToken).ConfigureAwait(false);
-            if (response.Headers.Location != null)
-            {
-                req.Endpoint = response.Headers.Location.ToString();
-                response = await _httpClient.SendAsync(await req.ToPostRequestAsync(), cancellationToken).ConfigureAwait(false);
-            }
             ThrowIfNotSuccessfulHttpResponse(response);
             var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false); // Do not use ReadAsStringAsync here
             var text = Encoding.UTF8.GetString(bytes);

--- a/SynologyDotNet.Core/SynoClient.cs
+++ b/SynologyDotNet.Core/SynoClient.cs
@@ -118,6 +118,7 @@ namespace SynologyDotNet
         /// </summary>
         /// <param name="server">The URI of the Synology server. Make sure it also contains the correct port number (By default it is 5000/5001 for HTTP/HTTPS)</param>
         /// <param name="connectors"></param>
+        [Obsolete("Please use " + nameof(Create) + " method")]
         public SynoClient(Uri server, params StationConnectorBase[] connectors)
             : this(server, false, connectors)
         {
@@ -127,8 +128,9 @@ namespace SynologyDotNet
         /// Initializes a new instance of the <see cref="SynoClient"/> class.
         /// </summary>
         /// <param name="server">The URI of the Synology server. Make sure it also contains the correct port number (By default it is 5000/5001 for HTTP/HTTPS)</param>
+        [Obsolete("Please use " + nameof(Create) + " method")]
         public SynoClient(Uri server)
-            : this(server, false, new StationConnectorBase[0])
+            : this(server, false, Array.Empty<StationConnectorBase>())
         {
         }
 
@@ -137,8 +139,9 @@ namespace SynologyDotNet
         /// </summary>
         /// <param name="server">The URI of the Synology server. Make sure it also contains the correct port number (By default it is 5000/5001 for HTTP/HTTPS)</param>
         /// <param name="bypassSslCertificateValidation">if set to <c>true</c> [bypass SSL certificate validation].</param>
+        [Obsolete("Please use " + nameof(Create) + " method")]
         public SynoClient(Uri server, bool bypassSslCertificateValidation)
-            : this(server, bypassSslCertificateValidation, new StationConnectorBase[0])
+            : this(server, bypassSslCertificateValidation, Array.Empty<StationConnectorBase>())
         {
         }
 
@@ -148,14 +151,37 @@ namespace SynologyDotNet
         /// <param name="server">The URI of the Synology server. Make sure it also contains the correct port number (By default it is 5000/5001 for HTTP/HTTPS)</param>
         /// <param name="bypassSslCertificateValidation">if set to <c>true</c> [bypass SSL certificate validation].</param>
         /// <param name="connectors">Adds the specified connectors to this client, so they will send requests with this client.</param>
+        [Obsolete("Please use " + nameof(Create) + " method")]
         public SynoClient(Uri server, bool bypassSslCertificateValidation, params StationConnectorBase[] connectors)
         {
-            _httpClient = HttpClientHelper.CreateHttpClient(server, System.Security.Authentication.SslProtocols.Tls12, bypassSslCertificateValidation);
+            _httpClient = HttpClientHelper.CreateHttpClient(
+                server,
+                System.Security.Authentication.SslProtocols.Tls12,
+                new SynoClientOptions(false, bypassSslCertificateValidation));
             if (connectors?.Length > 0 == true)
             {
                 _connectors.AddRange(connectors);
                 UpdateApiNamesFromConnectors(connectors);
             }
+        }
+
+        internal SynoClient(Uri server, SynoClientOptions options, params StationConnectorBase[] connectors)
+        {
+            _httpClient = HttpClientHelper.CreateHttpClient(server, System.Security.Authentication.SslProtocols.Tls12, options);
+            if (connectors?.Length > 0)
+            {
+                _connectors.AddRange(connectors);
+                UpdateApiNamesFromConnectors(connectors);
+            }
+        }
+
+        /// <summary>
+        /// Creates a SynoClient using the provided connection details
+        /// </summary>
+        /// <returns>The configured <see cref="SynoClient"/></returns>
+        public static async Task<SynoClient> Create(SynoConnectionDetails connectionDetails, params StationConnectorBase[] connectors)
+        {
+            return new SynoClient(await connectionDetails.Endpoint, connectionDetails.Options, connectors);
         }
 
         #endregion
@@ -269,6 +295,11 @@ namespace SynologyDotNet
             {
                 if (loginResult.Success && response.Headers.TryGetValues("Set-Cookie", out var cookies))
                 {
+                    if (response.RequestMessage.Headers.TryGetValues("Cookie", out var requestCookies))
+                    {
+                        cookies = cookies.Concat(requestCookies);
+                    }
+
                     var result = new SynoSession()
                     {
                         Name = session,
@@ -512,6 +543,11 @@ namespace SynologyDotNet
         public async Task<T> QueryObjectAsync<T>(RequestBuilder req, CancellationToken cancellationToken)
         {
             var response = await _httpClient.SendAsync(await req.ToPostRequestAsync(), cancellationToken).ConfigureAwait(false);
+            if (response.Headers.Location != null)
+            {
+                req.Endpoint = response.Headers.Location.ToString();
+                response = await _httpClient.SendAsync(await req.ToPostRequestAsync(), cancellationToken).ConfigureAwait(false);
+            }
             ThrowIfNotSuccessfulHttpResponse(response);
             var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false); // Do not use ReadAsStringAsync here
             var text = Encoding.UTF8.GetString(bytes);

--- a/SynologyDotNet.Core/SynoClientOptions.cs
+++ b/SynologyDotNet.Core/SynoClientOptions.cs
@@ -1,0 +1,24 @@
+namespace SynologyDotNet
+{
+    /// <summary>
+    /// Options that are considered when creating the http client
+    /// </summary>
+    public class SynoClientOptions
+    {
+        internal SynoClientOptions(bool quickConnectTunnelMode, bool disableCertificateValidation)
+        {
+            QuickConnectTunnelMode = quickConnectTunnelMode;
+            DisableCertificateValidation = disableCertificateValidation;
+        }
+
+        /// <summary>
+        /// If set to <code>true</code> the http client is configured for quick connect usage
+        /// </summary>
+        public bool QuickConnectTunnelMode { get; }
+        
+        /// <summary>
+        /// If set to <code>true</code> the certificate validation of the http client is disabled
+        /// </summary>
+        public bool DisableCertificateValidation { get; }
+    }
+}

--- a/SynologyDotNet.Core/SynoConnectionDetails.cs
+++ b/SynologyDotNet.Core/SynoConnectionDetails.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using SynologyDotNet.Core.Helpers;
+
+namespace SynologyDotNet
+{
+    /// <summary>
+    /// Provides the connection details to instantiate a <see cref="SynoClient"/>
+    /// </summary>
+    public class SynoConnectionDetails
+    {
+        internal Task<Uri> Endpoint { get; private set; }
+        internal SynoClientOptions Options { get;  private set; }
+
+        /// <summary>
+        /// Creates connection details for the given URI.
+        /// Make sure it also contains the correct port number (By default it is 5000/5001 for HTTP/HTTPS)
+        /// </summary>
+        /// <param name="server">The host including the port of the synology</param>
+        /// <param name="disableCertificateValidation">Optional flag to disable the ssl certificate validation</param>
+        public static SynoConnectionDetails ForUri(Uri server, bool disableCertificateValidation = false)
+        {
+            return new SynoConnectionDetails()
+            {
+                Endpoint = Task.FromResult<Uri>(server),
+                Options = new SynoClientOptions(false, disableCertificateValidation),
+            };
+        }
+        
+        /// <summary>
+        /// Creates connection details for the given QuickConnect id.
+        /// </summary>
+        /// <param name="quickConnectId">The QuickConnect id of the synology</param>
+        public static SynoConnectionDetails ForQuickConnectId(string quickConnectId)
+        {
+            return new SynoConnectionDetails()
+            {
+                Endpoint = QuickConnectUriResolver.Resolve(quickConnectId),
+                Options = new SynoClientOptions(true, false),
+            };
+        }
+    }
+}


### PR DESCRIPTION
Introducing the QuickConnect feature to connect to the NAS using the quickconnect.to service of Synology.

- implemented `QuickConnectUriResolver` to get the URI for a given QuickConnect id
- Created factory method to instantiate the SynoClient either
  - using a known URI
  - using a QuickConnect id
- Marked current constructors as obsolete to not break existing usages
- Made some changes to the HttpClientHelper to set a required Cookie when using QuickConnect